### PR TITLE
Save results from finalSel as a tabular in a .txt-file

### DIFF
--- a/case-studies/BSM/LLP/DisplacedHNL/analysis_HNL_read.py
+++ b/case-studies/BSM/LLP/DisplacedHNL/analysis_HNL_read.py
@@ -275,6 +275,9 @@ class analysis():
                 # Definition: Lxy = math.sqrt( (branchGenPtcl.At(daut1).X)**2 + (branchGenPtcl.At(daut1).Y)**2 )  
                 .Define("GenHNL_Lxy", "return sqrt(GenHNLElectron_vertex_x*GenHNLElectron_vertex_x + GenHNLElectron_vertex_y*GenHNLElectron_vertex_y)")
                 .Define("GenHNL_Lxyz","return sqrt(GenHNLElectron_vertex_x*GenHNLElectron_vertex_x + GenHNLElectron_vertex_y*GenHNLElectron_vertex_y + GenHNLElectron_vertex_z*GenHNLElectron_vertex_z)")
+
+                .Define("GenHNL_Lxyz_boost", "return GenHNL_Lxyz*GenHNL_mass/GenHNL_p")
+                .Define("GenHNL_Lxy_boost", "return GenHNL_Lxy*GenHNL_mass/GenHNL_pt")
                 
                 # Calculating the lifetime of the HNL
                 # Definition: t = Lxy * branchGenPtcl.At(i).Mass / (branchGenPtcl.At(i).PT * 1000 * 3E8)
@@ -600,6 +603,8 @@ class analysis():
                         "GenHNL_Lxyz",
                         "GenHNL_lifetime_xy",
                         "GenHNL_lifetime_xyz",
+                        "GenHNL_Lxyz_boost",
+                        "GenHNL_Lxy_boost",
                         ######## Reconstructed particles #######
                         "n_RecoTracks",
                         "RecoHNLParticles",

--- a/case-studies/BSM/LLP/DisplacedHNL/finalSel.py
+++ b/case-studies/BSM/LLP/DisplacedHNL/finalSel.py
@@ -324,8 +324,9 @@ NUM_CPUS = 2
 ###Produce TTrees
 DO_TREE=False
 DO_SCALE=True
+SAVE_TABULAR=False
 
 ###This part is standard to all analyses
 import config.runDataFrameFinal as rdf
 myana=rdf.runDataFrameFinal(baseDir,procDict,process_list,cut_list,variables,intLumi)
-myana.run(ncpu=NUM_CPUS, doTree=DO_TREE, doScale=DO_SCALE)
+myana.run(ncpu=NUM_CPUS, doTree=DO_TREE, doScale=DO_SCALE, saveTabular=SAVE_TABULAR)

--- a/case-studies/BSM/LLP/DisplacedHNL/finalSel_general.py
+++ b/case-studies/BSM/LLP/DisplacedHNL/finalSel_general.py
@@ -10,10 +10,13 @@ intLumi = 150e6 #pb^-1
 ###Link to the dictonary that contains all the cross section informations etc...
 procDict = "myFCCee_procDict_spring2021_IDEA.json"
 process_list=[
-    'HNL_eenu_30GeV_1p41e-6Ve',
+    # 'HNL_eenu_30GeV_1p41e-6Ve',
     # 'HNL_eenu_50GeV_1p41e-6Ve',
     # 'HNL_eenu_70GeV_1p41e-6Ve',
-    'HNL_eenu_90GeV_1p41e-6Ve',
+    # 'HNL_eenu_90GeV_1p41e-6Ve',
+    
+    # 'HNL_eenu_40GeV_1e-5Ve',
+    # 'HNL_eenu_30GeV_1e-5Ve',
 
     'p8_ee_Zee_ecm91',
     'p8_ee_Zbb_ecm91',
@@ -31,17 +34,18 @@ process_list=[
 cut_list = {
     #"sel1":"zed_leptonic_m.size() == 1 && zed_leptonic_m[0] > 80 &&  zed_leptonic_m[0] < 100"
     "selNone": "n_RecoTracks > -1",
-    "sel1FSGenEle": "n_FSGenElectron>0",
-    "sel1FSGenEle_eeInvMassGt80": "n_FSGenElectron>0 && FSGen_ee_invMass >80",
-    "sel1FSGenNu": "n_FSGenNeutrino>0",
+    # "sel1FSGenEle": "n_FSGenElectron>0",
+    # "sel1FSGenEle_eeInvMassGt80": "n_FSGenElectron>0 && FSGen_ee_invMass >80",
+    # "sel1FSGenNu": "n_FSGenNeutrino>0",
     "sel2RecoEle": "n_RecoElectrons==2",
     "sel2RecoEle_vetoes": "n_RecoElectrons==2 && n_RecoMuons==0 && n_RecoPhotons==0 && n_RecoJets==0 && n_RecoPhotons==0",
-    "sel2RecoEle_absD0Gt0p1": "n_RecoElectrons==2 && RecoElectronTrack_absD0[0]>0.1 && RecoElectronTrack_absD0[1]>0.1", #both electrons displaced
-    "sel2RecoEle_chi2Gt0p1": "n_RecoElectrons==2 && RecoDecayVertex.chi2>0.1", #good vertex
-    "sel2RecoEle_chi2Gt0p1_LxyzGt1": "n_RecoElectrons==2 && RecoDecayVertex.chi2>0.1 && Reco_Lxyz>1", #displaced vertex
+    # "sel2RecoEle_absD0Gt0p1": "n_RecoElectrons==2 && RecoElectronTrack_absD0[0]>0.1 && RecoElectronTrack_absD0[1]>0.1", #both electrons displaced
+    # "sel2RecoEle_chi2Gt0p1": "n_RecoElectrons==2 && RecoDecayVertex.chi2>0.1", #good vertex
+    # "sel2RecoEle_chi2Gt0p1_LxyzGt1": "n_RecoElectrons==2 && RecoDecayVertex.chi2>0.1 && Reco_Lxyz>1", #displaced vertex
     "sel2RecoEle_vetoes_MissingEnergyGt10": "n_RecoElectrons==2 && n_RecoMuons==0 && n_RecoPhotons==0 && n_RecoJets==0 && n_RecoPhotons==0 && RecoMissingEnergy_p[0]>10", #missing energy > 10 GeV
+    # "sel2RecoEle_vetoes_absD0Gt0p5": "n_RecoElectrons==2 && n_RecoMuons==0 && n_RecoPhotons==0 && n_RecoJets==0 && n_RecoPhotons==0 && RecoElectronTrack_absD0[0]>0.5 && RecoElectronTrack_absD0[1]>0.5", #both electrons displaced
     "sel2RecoEle_vetoes_MissingEnergyGt10_absD0Gt0p5": "n_RecoElectrons==2 && n_RecoMuons==0 && n_RecoPhotons==0 && n_RecoJets==0 && n_RecoPhotons==0 && RecoMissingEnergy_p[0]>10 && RecoElectronTrack_absD0[0]>0.5 && RecoElectronTrack_absD0[1]>0.5", #both electrons displaced
-    "sel2RecoEle_vetoes_MissingEnergyGt10_chi2Gt1_LxyzGt5": "n_RecoElectrons==2 && n_RecoMuons==0 && n_RecoPhotons==0 && n_RecoJets==0 && n_RecoPhotons==0 && RecoMissingEnergy_p[0]>10 && RecoDecayVertex.chi2>1 && Reco_Lxyz>5", #displaced vertex
+    # "sel2RecoEle_vetoes_MissingEnergyGt10_chi2Gt1_LxyzGt5": "n_RecoElectrons==2 && n_RecoMuons==0 && n_RecoPhotons==0 && n_RecoJets==0 && n_RecoPhotons==0 && RecoMissingEnergy_p[0]>10 && RecoDecayVertex.chi2>1 && Reco_Lxyz>5", #displaced vertex
 }
 
 
@@ -207,8 +211,9 @@ NUM_CPUS = 2
 ###Produce TTrees
 DO_TREE=False
 DO_SCALE=True
+SAVE_TABULAR=True
 
 ###This part is standard to all analyses
 import config.runDataFrameFinal as rdf
 myana=rdf.runDataFrameFinal(baseDir,procDict,process_list,cut_list,variables,intLumi)
-myana.run(ncpu=NUM_CPUS, doTree=DO_TREE, doScale=DO_SCALE)
+myana.run(ncpu=NUM_CPUS, doTree=DO_TREE, doScale=DO_SCALE, saveTabular=SAVE_TABULAR)

--- a/case-studies/BSM/LLP/DisplacedHNL/myFCCee_procDict_spring2021_IDEA.json
+++ b/case-studies/BSM/LLP/DisplacedHNL/myFCCee_procDict_spring2021_IDEA.json
@@ -11,6 +11,8 @@
     "HNL_eenu_12GeV_1p41e-6Ve": {"numberOfEvents": 50000, "sumOfWeights": 50000, "crossSection": 4.089e-10, "kfactor": 1.0, "matchingEfficiency": 1.0},
     "HNL_eenu_10GeV_1p41e-6Ve": {"numberOfEvents": 50000, "sumOfWeights": 50000, "crossSection": 4.195e-10, "kfactor": 1.0, "matchingEfficiency": 1.0},
     "HNL_eenu_5GeV_1p41e-6Ve":  {"numberOfEvents": 50000, "sumOfWeights": 50000, "crossSection": 4.93e-10, "kfactor": 1.0, "matchingEfficiency": 1.0},
+    "HNL_eenu_40GeV_1p41e-5Ve":  {"numberOfEvents": 50000, "sumOfWeights": 50000, "crossSection": 5.681e-08, "kfactor": 1.0, "matchingEfficiency": 1.0},
+    "HNL_eenu_30GeV_1e-5Ve":  {"numberOfEvents": 50000, "sumOfWeights": 50000, "crossSection": 3.339e-08, "kfactor": 1.0, "matchingEfficiency": 1.0},
     "HNL_eenu_40GeV_1e-3Ve": {"numberOfEvents": 50000, "sumOfWeights": 50000, "crossSection": 2.857e-4, "kfactor": 1.0, "matchingEfficiency": 1.0},
     "HNL_eenu_40GeV_1e-4Ve": {"numberOfEvents": 50000, "sumOfWeights": 50000, "crossSection": 2.857e-6, "kfactor": 1.0, "matchingEfficiency": 1.0},
     "HNL_eenu_40GeV_1e-5Ve": {"numberOfEvents": 50000, "sumOfWeights": 50000, "crossSection": 2.857e-8, "kfactor": 1.0, "matchingEfficiency": 1.0},

--- a/case-studies/BSM/LLP/DisplacedHNL/plots.py
+++ b/case-studies/BSM/LLP/DisplacedHNL/plots.py
@@ -323,12 +323,13 @@ colors = {}
 #colors['HNL_eenu_15GeV_1p41e-6Ve'] = ROOT.kBlue
 #colors['HNL_eenu_20GeV_1p41e-6Ve'] = ROOT.kMagenta
 #colors['HNL_eenu_20GeV_0p1Ve'] = ROOT.kRed
-colors['HNL_eenu_20GeV_0p1Ve_withBothAntiNu'] = ROOT.kMagenta
-colors['HNL_eenu_20GeV_0p1Ve_withBothAntiNu_localDelphes_v2'] = ROOT.kRed
-colors['HNL_eenu_50GeV_1p41e-6Ve_withBothAntiNu'] = ROOT.kCyan
-colors['HNL_eenu_50GeV_1p41e-6Ve_withBothAntiNu_localDelphes_v2'] = ROOT.kBlue
+# colors['HNL_eenu_20GeV_0p1Ve_withBothAntiNu'] = ROOT.kMagenta
+# colors['HNL_eenu_20GeV_0p1Ve_withBothAntiNu_localDelphes_v2'] = ROOT.kRed
+# colors['HNL_eenu_50GeV_1p41e-6Ve_withBothAntiNu'] = ROOT.kCyan
+# colors['HNL_eenu_50GeV_1p41e-6Ve_withBothAntiNu_localDelphes_v2'] = ROOT.kBlue
 
 
+colors['HNL_eenu_30GeV_1e-5Ve'] = ROOT.kGreen+1
 #colors['HNL_eenu_30GeV_1p41e-6Ve'] = ROOT.kBlack
 #colors['HNL_eenu_40GeV_1p41e-6Ve'] = ROOT.kRed
 #colors['HNL_eenu_50GeV_1p41e-6Ve'] = ROOT.kRed
@@ -351,10 +352,11 @@ plots['HNL'] = {'signal':{
     #'HNL_eenu_15GeV_1p41e-6Ve':['HNL_eenu_15GeV_1p41e-6Ve'],
     #'HNL_eenu_20GeV_1p41e-6Ve':['HNL_eenu_20GeV_1p41e-6Ve'],
     #'HNL_eenu_20GeV_0p1Ve':['HNL_eenu_20GeV_0p1Ve'],
-    'HNL_eenu_20GeV_0p1Ve_withBothAntiNu':['HNL_eenu_20GeV_0p1Ve_withBothAntiNu'],
-    'HNL_eenu_20GeV_0p1Ve_withBothAntiNu_localDelphes_v2':['HNL_eenu_20GeV_0p1Ve_withBothAntiNu_localDelphes_v2'],
-    'HNL_eenu_50GeV_1p41e-6Ve_withBothAntiNu':['HNL_eenu_50GeV_1p41e-6Ve_withBothAntiNu'],
-    'HNL_eenu_50GeV_1p41e-6Ve_withBothAntiNu_localDelphes_v2':['HNL_eenu_50GeV_1p41e-6Ve_withBothAntiNu_localDelphes_v2'],
+    # 'HNL_eenu_20GeV_0p1Ve_withBothAntiNu':['HNL_eenu_20GeV_0p1Ve_withBothAntiNu'],
+    # 'HNL_eenu_20GeV_0p1Ve_withBothAntiNu_localDelphes_v2':['HNL_eenu_20GeV_0p1Ve_withBothAntiNu_localDelphes_v2'],
+    # 'HNL_eenu_50GeV_1p41e-6Ve_withBothAntiNu':['HNL_eenu_50GeV_1p41e-6Ve_withBothAntiNu'],
+    # 'HNL_eenu_50GeV_1p41e-6Ve_withBothAntiNu_localDelphes_v2':['HNL_eenu_50GeV_1p41e-6Ve_withBothAntiNu_localDelphes_v2'],
+    'HNL_eenu_30GeV_1e-5Ve':['HNL_eenu_30GeV_1e-5Ve'],
     #'HNL_eenu_30GeV_1p41e-6Ve':['HNL_eenu_30GeV_1p41e-6Ve'],
     #'HNL_eenu_40GeV_1p41e-6Ve':['HNL_eenu_40GeV_1p41e-6Ve'],
     #'HNL_eenu_50GeV_1p41e-6Ve':['HNL_eenu_50GeV_1p41e-6Ve'],
@@ -382,10 +384,11 @@ legend = {}
 #legend['HNL_eenu_15GeV_1p41e-6Ve'] = 'm_{N} = 15 GeV, V_{e} = 1.41e-6'
 #legend['HNL_eenu_20GeV_1p41e-6Ve'] = 'm_{N} = 20 GeV, V_{e} = 1.41e-6'
 #legend['HNL_eenu_20GeV_0p1Ve'] = 'm_{N} = 20 GeV, V_{e} = 0.1'
-legend['HNL_eenu_20GeV_0p1Ve_withBothAntiNu'] = 'm_{N} = 20 GeV, V_{e} = 0.1, Delphes 3.4.2'
-legend['HNL_eenu_20GeV_0p1Ve_withBothAntiNu_localDelphes_v2'] = 'm_{N} = 20 GeV, V_{e} = 0.1, Delphes 3.5.1.pre01'
-legend['HNL_eenu_50GeV_1p41e-6Ve_withBothAntiNu'] = 'm_{N} = 50 GeV, V_{e} = 1.41e-6, Delphes 3.4.2'
-legend['HNL_eenu_50GeV_1p41e-6Ve_withBothAntiNu_localDelphes_v2'] = 'm_{N} = 50 GeV, V_{e} = 1.41e-6, Delphes 3.5.1.pre01'
+# legend['HNL_eenu_20GeV_0p1Ve_withBothAntiNu'] = 'm_{N} = 20 GeV, V_{e} = 0.1, Delphes 3.4.2'
+# legend['HNL_eenu_20GeV_0p1Ve_withBothAntiNu_localDelphes_v2'] = 'm_{N} = 20 GeV, V_{e} = 0.1, Delphes 3.5.1.pre01'
+# legend['HNL_eenu_50GeV_1p41e-6Ve_withBothAntiNu'] = 'm_{N} = 50 GeV, V_{e} = 1.41e-6, Delphes 3.4.2'
+# legend['HNL_eenu_50GeV_1p41e-6Ve_withBothAntiNu_localDelphes_v2'] = 'm_{N} = 50 GeV, V_{e} = 1.41e-6, Delphes 3.5.1.pre01'
+legend['HNL_eenu_30GeV_1e-5Ve'] = 'm_{N} = 30 GeV, V_{e} = 1e-5'
 #legend['HNL_eenu_30GeV_1p41e-6Ve'] = 'm_{N} = 30 GeV, V_{e} = 1.41e-6'
 #legend['HNL_eenu_40GeV_1p41e-6Ve'] = 'm_{N} = 40 GeV, V_{e} = 1.41e-6'
 #legend['HNL_eenu_50GeV_1p41e-6Ve'] = 'm_{N} = 50 GeV, V_{e} = 1.41e-6'

--- a/case-studies/BSM/LLP/DisplacedHNL/plots_general.py
+++ b/case-studies/BSM/LLP/DisplacedHNL/plots_general.py
@@ -180,48 +180,54 @@ effPlots = {
 selections = {}
 selections['HNL']  = [
     "selNone",
-    "sel1FSGenEle",
-    "sel1FSGenEle_eeInvMassGt80",
-    "sel1FSGenNu",
+    # "sel1FSGenEle",
+    # "sel1FSGenEle_eeInvMassGt80",
+    # "sel1FSGenNu",
     "sel2RecoEle",
     "sel2RecoEle_vetoes",
-    "sel2RecoEle_absD0Gt0p1",
+    # "sel2RecoEle_absD0Gt0p1",
     "sel2RecoEle_vetoes_MissingEnergyGt10",
+    # "sel2RecoEle_vetoes_absD0Gt0p5",
     "sel2RecoEle_vetoes_MissingEnergyGt10_absD0Gt0p5",
 ]
 
 extralabel = {}
 extralabel['selNone'] = "No selection"
-extralabel['sel1FSGenEle'] = "Selection: At least 1 final state gen electron"
-extralabel['sel1FSGenEle_eeInvMassGt80'] = "Selection: At least 1 final state gen electron, gen ee inv mass > 80 GeV"
-extralabel['sel1FSGenNu'] = "Selection: At least 1 final state gen neutrino"
+# extralabel['sel1FSGenEle'] = "Selection: At least 1 final state gen electron"
+# extralabel['sel1FSGenEle_eeInvMassGt80'] = "Selection: At least 1 final state gen electron, gen ee inv mass > 80 GeV"
+# extralabel['sel1FSGenNu'] = "Selection: At least 1 final state gen neutrino"
 extralabel['sel2RecoEle'] = "Selection: Exactly 2 reco electrons"
 extralabel['sel2RecoEle_vetoes'] = "Selection: Exactly 2 reco electrons; No reco muons, jets, or photons"
-extralabel['sel2RecoEle_absD0Gt0p1'] = "Selection: Exactly 2 reco electrons with |d_0|>0.1 mm"
+# extralabel['sel2RecoEle_absD0Gt0p1'] = "Selection: Exactly 2 reco electrons with |d_0|>0.1 mm"
 extralabel['sel2RecoEle_vetoes_MissingEnergyGt10'] = "Selection: Exactly 2 reco electrons; No reco muons, jets, or photons; Missing energy > 10 GeV"
+# extralabel['sel2RecoEle_vetoes_absD0Gt0p5'] = "Selection: Exactly 2 reco electrons with |d_0|>0.1 mm; No reco muons, jets, or photons"
 extralabel['sel2RecoEle_vetoes_MissingEnergyGt10_absD0Gt0p5'] = "Selection: Exactly 2 reco electrons with |d_0|>0.5 mm; No reco muons, jets, or photons; Missing energy > 10 GeV"
 
 colors = {}
-colors['HNL_eenu_30GeV_1p41e-6Ve'] = ROOT.kOrange
+# colors['HNL_eenu_30GeV_1p41e-6Ve'] = ROOT.kOrange+1
 # colors['HNL_eenu_50GeV_1p41e-6Ve'] = ROOT.kRed
 # colors['HNL_eenu_70GeV_1p41e-6Ve'] = ROOT.kBlue
-colors['HNL_eenu_90GeV_1p41e-6Ve'] = ROOT.kGreen+2
-colors['Zee'] = ROOT.kBlack
+# colors['HNL_eenu_90GeV_1p41e-6Ve'] = ROOT.kGreen+1
+
+colors['HNL_eenu_30GeV_1e-5Ve'] = ROOT.kGreen+1
+
+colors['Zee'] = ROOT.kGray+2
 #colors['Zee_dev'] = ROOT.kRed
 #colors['test_Zee_for_Juliette'] = ROOT.kBlue
 #colors['test_Zee_for_Juliette_v2'] = ROOT.kMagenta
-colors['Zbb'] = ROOT.kRed
-colors['Ztautau'] = ROOT.kBlue
-colors['Zcc'] = ROOT.kMagenta
-colors['Zuds'] = ROOT.kCyan
-
+colors['Zbb'] = ROOT.kAzure-4
+colors['Ztautau'] = ROOT.kRed-3
+colors['Zcc'] = ROOT.kCyan-9
+colors['Zuds'] = ROOT.kViolet-4
 
 plots = {}
 plots['HNL'] = {'signal':{
-                    'HNL_eenu_30GeV_1p41e-6Ve':['HNL_eenu_30GeV_1p41e-6Ve'],
+                    # 'HNL_eenu_30GeV_1p41e-6Ve':['HNL_eenu_30GeV_1p41e-6Ve'],
                     # 'HNL_eenu_50GeV_1p41e-6Ve':['HNL_eenu_50GeV_1p41e-6Ve'],
                     # 'HNL_eenu_70GeV_1p41e-6Ve':['HNL_eenu_70GeV_1p41e-6Ve'],
-                    'HNL_eenu_90GeV_1p41e-6Ve':['HNL_eenu_90GeV_1p41e-6Ve'],
+                    # 'HNL_eenu_90GeV_1p41e-6Ve':['HNL_eenu_90GeV_1p41e-6Ve'],
+
+                    'HNL_eenu_30GeV_1e-5Ve':['HNL_eenu_30GeV_1e-5Ve'],
 },
                 'backgrounds':{
                     'Zee':['p8_ee_Zee_ecm91'],
@@ -237,10 +243,12 @@ plots['HNL'] = {'signal':{
 
 
 legend = {}
-legend['HNL_eenu_30GeV_1p41e-6Ve'] = 'm_{N} = 30 GeV, V_{e} = 1.41e-6'
+# legend['HNL_eenu_30GeV_1p41e-6Ve'] = 'm_{N} = 30 GeV, V_{e} = 1.41e-6'
 # legend['HNL_eenu_50GeV_1p41e-6Ve'] = 'm_{N} = 50 GeV, V_{e} = 1.41e-6'
 # legend['HNL_eenu_70GeV_1p41e-6Ve'] = 'm_{N} = 70 GeV, V_{e} = 1.41e-6'
-legend['HNL_eenu_90GeV_1p41e-6Ve'] = 'm_{N} = 90 GeV, V_{e} = 1.41e-6'
+# legend['HNL_eenu_90GeV_1p41e-6Ve'] = 'm_{N} = 90 GeV, V_{e} = 1.41e-6'
+
+legend['HNL_eenu_30GeV_1e-5Ve']  = 'm_{N} = 30 GeV, V_{e} = 1e-5'
 
 legend['Zee'] = 'e^{+}e^{-} #rightarrow Z #rightarrow ee'
 legend['Zbb'] = 'e^{+}e^{-} #rightarrow Z #rightarrow bb'

--- a/case-studies/BSM/LLP/DisplacedHNL/runAnalysis_general.sh
+++ b/case-studies/BSM/LLP/DisplacedHNL/runAnalysis_general.sh
@@ -21,7 +21,9 @@ python3 analysis_general.py -i /eos/experiment/fcc/ee/generation/DelphesEvents/s
 
 ########################################################### signals ######################################################################
 # private signal samples
-python3 analysis_general.py -i /afs/cern.ch/user/l/lrygaard/public/HNL_root_files/HNL_eenu_90GeV_1p41e-6Ve.root
+# python3 analysis_general.py -i /afs/cern.ch/user/l/lrygaard/public/HNL_root_files/HNL_eenu_90GeV_1p41e-6Ve.root
 #python3 analysis_general.py -i /afs/cern.ch/user/l/lrygaard/public/HNL_root_files/HNL_eenu_70GeV_1p41e-6Ve.root
 #python3 analysis_general.py -i /afs/cern.ch/user/l/lrygaard/public/HNL_root_files/HNL_eenu_50GeV_1p41e-6Ve.root
-python3 analysis_general.py -i /afs/cern.ch/user/l/lrygaard/public/HNL_root_files/HNL_eenu_30GeV_1p41e-6Ve.root
+# python3 analysis_general.py -i /afs/cern.ch/user/l/lrygaard/public/HNL_root_files/HNL_eenu_30GeV_1p41e-6Ve.root
+python3 analysis_general.py -i /afs/cern.ch/user/l/lrygaard/public/HNL_root_files/HNL_eenu_30GeV_1e-5Ve.root
+python3 analysis_general.py -i /afs/cern.ch/user/l/lrygaard/public/HNL_root_files/HNL_eenu_40GeV_1e-5Ve.root


### PR DESCRIPTION
Several small changes in the code:
- In finalSel.py and finalSel_general.py: option to set the input parameter saveTab to true and the program will save the output in LaTeX format in a .txt-file. Works together with latest commits in FCCAnalysis HNLedit branch https://github.com/jalimena/FCCAnalyses/pull/3.
- To get proper output from finalSel with correct uncertainty and efficiency, the selections must be given in correct order, so some previous cuts are currently commented out.
- Added a few more .root-files stored locally and can run with runAnalysis_general.sh
- To check the relativity boost for each event GenHNL_Lxy_boost and GenHNL_Lxyz_boost are added, calculated as: Lxyz_boost = Lxyz * HNL_mass / HNL_p.